### PR TITLE
Rename files, replace usage in code, docs, package.json, repo names a…

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-Juttle Graphite Backend
+Juttle Graphite Adapter
 Copyright 2015 Jut, Inc.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Juttle Graphite Backend
+# Juttle Graphite Adapter
 
-[![Build Status](https://magnum.travis-ci.com/juttle/graphite-backend.svg?token=y7186y8XHjB7CcxwUcoX)](https://magnum.travis-ci.com/juttle/graphite-backend)
+[![Build Status](https://magnum.travis-ci.com/juttle/juttle-graphite-adapter.svg?token=y7186y8XHjB7CcxwUcoX)](https://magnum.travis-ci.com/juttle/juttle-graphite-adapter)
 
-Juttle graphite backend used to read and write metric data to an existing
+Juttle graphite adapter used to read and write metric data to an existing
 graphite setup.
 
 
@@ -21,7 +21,7 @@ Make sure the following is in your environment:
 
 Add the following to ~/.juttle/config.json:
 
-    "juttle-graphite-backend": {
+    "juttle-graphite-adapter": {
         "carbon": {
             "host": "localhost",
             "port": 2003
@@ -48,7 +48,7 @@ Graphite stores metrics with:
     timestamp - the timestamp associated with this metric as an integer of
                 seconds since epoch.
 
-With this backend plugin we will simply map data points contain the same fields
+With this adapter we will simply map data points contain the same fields
 `name`,`value`, and `time` fields to a graphite metric. All other points missing
 these will be simply not written and a warning will be issued.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-function GraphiteBackend(config) {
+function GraphiteAdapter(config) {
     return {
         name: 'graphite',
         read: require('./read')(config),
@@ -6,4 +6,4 @@ function GraphiteBackend(config) {
     };
 }
 
-module.exports = GraphiteBackend;
+module.exports = GraphiteAdapter;

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "juttle-graphite-backend",
+  "name": "juttle-graphite-adapter",
   "version": "0.1.0",
-  "description": "juttle graphite backend",
+  "description": "juttle graphite adapter",
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test"
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/juttle/juttle-graphite-backend"
+    "url": "http://github.com/juttle/juttle-graphite-adapter"
   },
   "author": "Rodney Gomes <rodney@jut.io>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/juttle/juttle-graphite-backend/issues"
+    "url": "https://github.com/juttle/juttle-graphite-adapter/issues"
   },
-  "homepage": "https://github.com/juttle/juttle-graphite-backend",
+  "homepage": "https://github.com/juttle/juttle-graphite-adapter",
   "dependencies": {
     "bluebird": "^3.0.5",
     "isomorphic-fetch": "^2.2.0",

--- a/test/graphite.spec.js
+++ b/test/graphite.spec.js
@@ -7,7 +7,7 @@ var uuid = require('uuid');
 
 var Juttle = require('juttle/lib/runtime').Juttle;
 
-Juttle.backends.register('graphite', graphite({
+Juttle.adapters.register('graphite', graphite({
     carbon: {
         host: 'localhost',
         port: 2003
@@ -20,7 +20,7 @@ Juttle.backends.register('graphite', graphite({
     }
 }, Juttle));
 
-describe('graphite-backend API tests', function () {
+describe('graphite-adapter API tests', function () {
 
     it('fails when provided an invalid filter exprssion', function() {
         return check_juttle({


### PR DESCRIPTION
Replace usage of the term backend with adapter.

refs: https://github.com/juttle/juttle/pull/269
