### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/juttle/juttle-graphite-adapter",
   "bugs": "https://github.com/juttle/juttle-graphite-adapter/issues",
   "license": "Apache-2.0",
-  "author": "Rodney Gomes <rodney@jut.io>",
   "main": "lib/index.js",
   "repository": "juttle/juttle-graphite-adapter",
   "scripts": {


### PR DESCRIPTION
This is part of an effort to make sure all our `package.json` are ready for publishing and contain the same metadata.
