### PR TITLE
Drop sourceType property from read

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -13,7 +13,6 @@ var fetch = require('isomorphic-fetch');
 
 var Read = function(config) {
     return Juttle.proc.source.extend({
-        sourceType: 'batch',
         procName: 'read-graphite',
 
         initialize: function(options, params, pname, location, program, juttle) {


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110