### PR TITLE
Update to juttle 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
     - docker
 
 before_script:
-    - npm install juttle@^0.2.0
+    - npm install juttle@^0.3.0
     - docker pull juttle/graphite:1
     - docker run -d --name graphite -p 8080:80 -p 2003:2003 -v `pwd`/scripts/storage-schemas.conf:/opt/graphite/conf/storage-schemas.conf juttle/graphite:1
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uuid": "^2.0.1"
   },
   "peerDependencies": {
-    "juttle": "0.2.x"
+    "juttle": ">= 0.3.0"
   },
   "engines": {
     "node": ">=4.2.0",


### PR DESCRIPTION
Using >= 0.3.0, the format used by other adapters.

@demmer @bkutil @rlgomes 

Can one of you publish to npm once this is merged?