### PR TITLE
remove unnecessary node based filtering from read

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -47,12 +47,8 @@ var Read = function(config) {
                 'Authorization': 'Basic ' + auth.toString('base64')
             };
 
-            this.filter = null;
             var name = null;
             if (params.filter_ast) {
-                var compiler = new Juttle.FilterJSCompiler();
-                var source = compiler.compile(params.filter_ast);
-
                 var expression =  params.filter_ast.expression;
                 if (expression.type === 'BinaryExpression' &&
                     (expression.operator === '==' || expression.operator === '=~')) {
@@ -63,11 +59,6 @@ var Read = function(config) {
                             name = right.value;
                         }
                     }
-                }
-
-                if (name) {
-                    /* jshint evil: true */
-                    this.filter = eval(source);
                 }
             }
 
@@ -122,11 +113,6 @@ var Read = function(config) {
                             points.push(point);
                         }
                     });
-
-                    if (self.filter !== null) {
-                        points = points.filter(self.filter);
-                    }
-
 
                     if (points.length !== 0 ) {
                         self.emit(points);


### PR DESCRIPTION
fixes #21

this was here accidentally as we do not support filtering in the
graphite read call for anything other than exact `name=xxx` or wildcard
based matching `name~x.*` filtering that is done in graphite
(http://graphite.readthedocs.org/en/1.0/url-api.html#target)