### PR TITLE
Update README to reflect juttle-config change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ within Juttle. To do so, add the following to your `~/.juttle/config.json` file:
 ```json
 {
     "adapters": {
-        "juttle-graphite-adapter": {
+        "graphite": {
             "carbon": {
                 "host": "localhost",
                 "port": 2003


### PR DESCRIPTION
With juttle 0.3.0, adapter config elements below .juttle-config should
be XXX and not juttle-xxx-adapter.

Update README to reflect this.

@rlgomes 