### PR TITLE
remove require('juttle/xxx') references

### DIFF
--- a/lib/graphite.js
+++ b/lib/graphite.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var buffer = require('buffer');
-var JuttleMoment = require('juttle/lib/runtime/types').JuttleMoment;
-var logger = require('juttle/lib/logger').getLogger('graphite');
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+var logger = JuttleAdapterAPI.getLogger('graphite');
 var net = require('net');
 var url = require('url');
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var AdapterRead = JuttleAdapterAPI.AdapterRead;
 var graphite = require('./graphite');
-var JuttleMoment = require('juttle/lib/runtime/types').JuttleMoment;
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
 
 class ReadGraphite extends AdapterRead {
     constructor(options, params) {


### PR DESCRIPTION
this should have been taken care of when we ported to 0.5.0