### PR TITLE
updated to use juttle 0.7.0

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -17,10 +17,10 @@ class ReadGraphite extends AdapterRead {
                 (ast.operator === '==' || ast.operator === '=~')) {
                 var left = ast.left;
                 var right = ast.right;
-                if (left && right) {
-                    if (left.name === 'name' && right.type === 'StringLiteral') {
-                        name = right.value;
-                    }
+                if (left.type === 'Field' &&
+                    left.name === 'name' &&
+                    right.type === 'StringLiteral') {
+                    name = right.value;
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lazy-socket": "0.0.4",
     "underscore": "^1.8.3"
   },
-  "juttleAdapterAPI": "^0.5.0",
+  "juttleAdapterAPI": "^0.7.0",
   "devDependencies": {
     "bluebird-retry": "^0.5.2",
     "chai": "^3.4.1",


### PR DESCRIPTION
no changes required since we're not using any built in filtering
features and instead checking for the simple appearance of the single
name=/~value in the filter AST.
